### PR TITLE
Rename composeApp to ComposeApp, notice the capitalization

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -26,9 +26,20 @@ kotlin {
         iosSimulatorArm64()
     ).forEach { iosTarget ->
         iosTarget.binaries.framework {
-            //baseName = "MacaoSuiDemoKt"
+
+            // All swift packages kmp modules have to be exported through the umbrella
+            // framework so the swift side can see it.
             export(project(":auth-firebase"))
-            baseName = "composeApp"
+            export(libs.component.toolkit)
+
+            // Macao convention requires iOS umbrella framework to be named "ComposeApp".
+
+            // DON'T
+            // baseName = "MacaoServerUiDemoKt"
+
+            // OK
+            baseName = "ComposeApp"
+
             isStatic = true
             xcf.add(this)
         }
@@ -76,7 +87,7 @@ kotlin {
             // Macao Libs
             implementation(libs.koin.core)
             implementation(project(":macao-sdk-koin"))
-            implementation(libs.component.toolkit)
+            api(libs.component.toolkit)
             implementation(libs.amadeus.api)
 
             // Decide which flavor to use based on a build environment variable

--- a/composeApp/src/iosMain/kotlin/com.macaosoftware.sdui.app/Bindings.kt
+++ b/composeApp/src/iosMain/kotlin/com.macaosoftware.sdui.app/Bindings.kt
@@ -5,8 +5,7 @@ import com.macaosoftware.app.MacaoKoinApplication
 import com.macaosoftware.app.MacaoKoinApplicationState
 import com.macaosoftware.app.StartupTaskRunnerDefault
 import com.macaosoftware.plugin.AppTheme
-import com.macaosoftware.plugin.account.FirebaseAccountPlugin
-import com.macaosoftware.plugin.account.FirebaseAuthKmpWrapper
+import com.macaosoftware.plugin.account.AccountPlugin
 import com.macaosoftware.sdui.app.startup.ComposeAppRootComponentInitializer
 import com.macaosoftware.sdui.app.startup.DatabaseMigrationStartupTask
 import com.macaosoftware.sdui.app.startup.LaunchDarklyStartupTask
@@ -34,11 +33,10 @@ fun buildDemoMacaoApplication(
 }
 
 fun createPlatformBridge(
-    firebaseAuthKmpWrapper: FirebaseAuthKmpWrapper
+    accountPlugin: AccountPlugin
 ): IosBridge {
 
     // val accountPlugin = SupabaseAccountPlugin()
-    val accountPlugin = FirebaseAccountPlugin(firebaseAuthKmpWrapper)
 
     return IosBridge(
         accountPlugin = accountPlugin

--- a/iOSDemoApp/iOSDemoApp/ContentView.swift
+++ b/iOSDemoApp/iOSDemoApp/ContentView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 import UIKit
-import composeApp
+import ComposeApp
 
 struct ComposeView : UIViewControllerRepresentable {
 

--- a/iOSDemoApp/iOSDemoApp/MacaoDemoApp.swift
+++ b/iOSDemoApp/iOSDemoApp/MacaoDemoApp.swift
@@ -1,20 +1,25 @@
 import SwiftUI
-import composeApp
+import ComposeApp
 import FirebaseAuthKmp
 import iOSDemoAppPackage
 
 @main
 struct MacaoDemoApp: App {
     
-    let iosBridge = BindingsKt.createPlatformBridge(
-        firebaseAuthKmpWrapper: FirebaseAuthKmpWrapperImpl()
-    )
+    let accountPlugin: AccountPlugin
+    let iosBridge: IosBridge
     
     // register app delegate for Firebase setup
-    @UIApplicationDelegateAdaptor(MacaoDemoAppDelegate.self) var delegate
+    // @UIApplicationDelegateAdaptor(MacaoDemoAppDelegate.self) var delegate
     
     init() {
-        // FirebaseAuthKmpInitializer().applicationStart()
+        // If using @UIApplicationDelegateAdaptor then comment out bellow line
+        FirebaseAuthKmpInitializer().applicationStart()
+        
+        accountPlugin = FirebaseAccountPlugin(
+            firebaseAuthKmpWrapper: FirebaseAuthKmpWrapperImpl()
+        )
+        iosBridge = BindingsKt.createPlatformBridge(accountPlugin: accountPlugin)
     }
     
     var body: some Scene {


### PR DESCRIPTION
Move the FirebaseAccountPlugin creation to swift side. This makes possible to have an iOSBridge function factory that don;t rely on specific vendor interfaces but just the Macao AccountPlugin interface.